### PR TITLE
Add Piano Projector to the collection

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -77,6 +77,13 @@ export const initialSites: Site[] = [
     url: 'https://synth.playtronica.com',
     tags: ['synth', 'webaudio', 'collection'],
     description: 'A curated collection of web-based synthesizers by Playtronica.',
+  },
+  {
+    id: 'piano-projector',
+    name: 'Piano Projector',
+    url: 'https://pianoprojector.app',
+    tags: ['keyboard'],
+    description: 'A versatile and easy-to-use on-screen virtual piano keyboard.',
   }
 ];
 


### PR DESCRIPTION
Add Piano Projector to the collection. Piano Projector is an on-screen virtual piano keyboard that can be controlled by a MIDI controller.
https://pianoprojector.app