### PR TITLE
Added PLAINDOUND HEXATONE site

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -2,6 +2,13 @@ import { Site } from './types';
 
 export const initialSites: Site[] = [
   {
+    id: 'hexatone',
+    name: 'PLAINSOUND HEXATONE',
+    url: 'https://hexatone.plainsound.org',
+    tags: ['synth', 'webaudio', 'webmidi', 'lumatone', 'isomorphic keyboard'],
+    description: 'A microtonal app for mapping keyboards and 2D controllers to custom tunings.'
+  },
+  {
     id: 'microtonal',
     name: 'microtonal',
     url: 'https://www.websynths.com/microtonal/',


### PR DESCRIPTION
Hello, I am enjoying using MIDIweb on ioS and at last having functional MIDI on phone and tablet webapps. I have been working on an isomorphic touch controllable microtonal keyboard with a curated list of tunings and automatic mapping of incoming 2D geometries (only Lumatone and AXIS-49 are currently plug-and-play, but more are coming; generic MIDI keyboards work as well of course. I already put up a banner advising users on ioS about your project, it would be nice to be part of the curated list available to users!