### PR TITLE
Add Piano Trainer Studio

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -125,6 +125,14 @@ export const initialSites: Site[] = [
     description:
       'A versatile and easy-to-use on-screen virtual piano keyboard.',
   },
+    {
+    id: 'piano-trainer-studio',
+    name: 'Piano Trainer Studio',
+    url: 'https://pianotrainerstudio.com',
+    tags: ['training', 'piano', 'midi', 'playback', 'webaudio'],
+    description:
+      'Interactive piano practice app with sheet music playback, MIDI input, and training modes for learning songs.',
+  },
 ];
 
 export const allTags = Array.from(


### PR DESCRIPTION
Adds Piano Trainer Studio to the MIDIWeb Hub directory.

Piano Trainer Studio is a browser-based piano practice app that supports:
- real-time MIDI input
- sheet music playback (MusicXML)
- interactive training modes (realtime, wait mode, 1-handed follow me)
- Optional LED training

URL: https://pianotrainerstudio.com
Github: https://github.com/ztbishop/piano-trainer-studio