### PR TITLE
Add supporter metadata and subtle listing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ If you are browsing on **iOS**, **iPadOS**, **macOS**, or **visionOS**, MIDIWeb 
 
 Find out more at **[midiweb.cc](https://midiweb.cc)**.
 
+## Sponsorship
+
+MIDIWeb Hub may recognise supporters who help fund the project. Sponsorship does not guarantee inclusion, ranking, endorsement, or editorial preference. All listed sites must still be relevant to WebMIDI, browser-based music-making, music learning, or creative music technology.
+
 ## Independence and non-affiliation
 
 **MIDIWeb** and **MIDIWeb Hub** are independent projects created by **5of12**.

--- a/README.md
+++ b/README.md
@@ -112,21 +112,21 @@ A few practical suggestions:
 - use the canonical site URL
 - check that the link works before submitting
 
-## About MIDIWeb
+## About MIDIWeb Browser
 
-**MIDIWeb** is a browser for Apple platforms that helps users explore websites using WebMIDI.
+**[MIDIWeb Browser](https://apps.apple.com/gb/app/midiweb-browser/id6757226617)** is an App for Apple platforms that helps users explore websites using WebMIDI.
 
-If you are browsing on **iOS**, **iPadOS**, **macOS**, or **visionOS**, MIDIWeb offers a dedicated way to access WebMIDI experiences on Apple devices.
+If you are browsing on **iOS**, **iPadOS**, **macOS**, or **visionOS**, [MIDIWeb](https://apps.apple.com/gb/app/midiweb-browser/id6757226617) offers a dedicated way to access WebMIDI experiences on Apple devices.
 
 Find out more at **[midiweb.cc](https://midiweb.cc)**.
 
 ## Sponsorship
 
-MIDIWeb Hub may recognise supporters who help fund the project. Sponsorship does not guarantee inclusion, ranking, endorsement, or editorial preference. All listed sites must still be relevant to WebMIDI, browser-based music-making, music learning, or creative music technology.
+MIDIWeb Hub may recognise supporters who help fund the MIDIWeb Browser and/or MIDIWeb Hub projects. Sponsorship does not guarantee inclusion, ranking, endorsement, or editorial preference. All listed sites must still be relevant to WebMIDI, browser-based music-making, music learning, or creative music technology.
 
 ## Independence and non-affiliation
 
-**MIDIWeb** and **MIDIWeb Hub** are independent projects created by **5of12**.
+**MIDIWeb Browser** and **MIDIWeb Hub** are independent projects created by **5of12**.
 
 They are **not affiliated with, endorsed by, sponsored by, or officially connected with The MIDI Association**. Any references to MIDI, WebMIDI, MIDI standards, or related technologies are used for descriptive and informational purposes only.
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MIDIWeb Hub</title>
+    <title>MIDIWeb Hub - WebMIDI Directory</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,9 +153,9 @@ export default function App() {
             </span>
           </h2>
           <p className="text-lg text-zinc-400 leading-relaxed">
-            A curated directory of synthesizers, utilities, and experiments that
+            A lovingly curated directory of synths, utilities, teaching tools and experiments that
             leverage the Web MIDI API directly in your browser. Connect your
-            MIDI controller and start playing.
+            MIDI controller and start playing!
           </p>
         </div>
 
@@ -246,7 +246,7 @@ export default function App() {
                 <button
                   key={tag}
                   onClick={() => toggleTag(tag)}
-                  className={`px-3 py-1.5 text-sm font-medium rounded-lg border transition-all duration-200 ${
+                  className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all duration-200 ${
                     isSelected
                       ? 'bg-emerald-500/10 border-emerald-500/50 text-emerald-400'
                       : 'bg-zinc-900 border-zinc-800 text-zinc-400 hover:border-zinc-700 hover:text-zinc-200'

--- a/src/components/SiteCard.tsx
+++ b/src/components/SiteCard.tsx
@@ -36,11 +36,18 @@ export function SiteCard({ site, status }: SiteCardProps) {
           </div>
         </div>
         
-        <h3 className={`text-lg font-semibold mb-2 transition-colors ${
-          status === 'down' ? 'text-orange-400 group-hover:text-orange-300' : 'text-zinc-100 group-hover:text-emerald-400'
-        }`}>
-          {site.name}
-        </h3>
+        <div className="mb-2 flex items-center gap-2">
+          <h3 className={`text-lg font-semibold transition-colors ${
+            status === 'down' ? 'text-orange-400 group-hover:text-orange-300' : 'text-zinc-100 group-hover:text-emerald-400'
+          }`}>
+            {site.name}
+          </h3>
+          {site.sponsor?.active && (
+            <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-emerald-300">
+              Supporter
+            </span>
+          )}
+        </div>
         
         <p className="text-sm text-zinc-400 mb-4 line-clamp-2 flex-1">
           {site.description || 'A WebMIDI-capable website.'}

--- a/src/components/SiteRow.tsx
+++ b/src/components/SiteRow.tsx
@@ -35,6 +35,11 @@ export function SiteRow({ site, status }: SiteRowProps) {
           }`}>
             {site.name}
           </h3>
+          {site.sponsor?.active && (
+            <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-emerald-300">
+              Supporter
+            </span>
+          )}
           {status === 'loading' && <Loader2 className="w-4 h-4 text-zinc-500 animate-spin flex-shrink-0" />}
           {status === 'up' && <span title="Site is reachable" className="flex-shrink-0 flex"><CheckCircle2 className="w-4 h-4 text-emerald-500" /></span>}
           {status === 'down' && <span title="Site may be unreachable" className="flex-shrink-0 flex"><AlertCircle className="w-4 h-4 text-orange-500" /></span>}

--- a/src/data.ts
+++ b/src/data.ts
@@ -19,7 +19,7 @@ export const initialSites: Site[] = [
     id: 'hexatone',
     name: 'PLAINSOUND HEXATONE',
     url: 'https://hexatone.plainsound.org',
-    tags: ['synth', 'webaudio', 'lumatone', 'isomorphic keyboard'],
+    tags: ['synth', 'webaudio', 'lumatone', 'isomorphic', 'keyboard'],
     description:
       'A microtonal app for mapping keyboards and 2D controllers to custom tunings.',
   },

--- a/src/data.ts
+++ b/src/data.ts
@@ -179,6 +179,11 @@ export const initialSites: Site[] = [
     ],
     description:
       'Practice drums in the browser with 2000+ songs as drum sheet or rhythm game. AI-generated transcription from MP3/YouTube, MIDI input from electronic kits, real-time scoring, sheet editor, and PDF/MIDI export.',
+    sponsor: {
+      active: true,
+      tier: 'supporter',
+      since: '2026-05-11',
+    },
   },
 ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,19 @@
+export type SponsorTier = 'supporter' | 'sponsor' | 'featured-sponsor';
+
+export interface SponsorInfo {
+  active: boolean;
+  tier: SponsorTier;
+  since?: string;
+  note?: string;
+}
+
 export interface Site {
   id: string;
   name: string;
   url: string;
   tags: string[];
   description?: string;
+  sponsor?: SponsorInfo;
 }
 
 export type ViewMode = 'grid' | 'list';


### PR DESCRIPTION
### Motivation
- Provide first-class, optional sponsorship metadata so supporters can be recognised in the public directory without affecting editorial behaviour. 
- Mark PlayDrumsOnline as an active supporter for the public record while keeping listing order and search unchanged. 

### Description
- Add `SponsorTier` and `SponsorInfo` types and an optional `sponsor?: SponsorInfo` field on `Site` in `src/types.ts`. 
- Mark `PlayDrumsOnline` with `sponsor: { active: true, tier: 'supporter', since: '2026-05-11' }` in `src/data.ts`. 
- Render a subtle `Supporter` badge when `site.sponsor?.active` is true in both `src/components/SiteCard.tsx` and `src/components/SiteRow.tsx`. 
- Add a short `## Sponsorship` policy blurb to `README.md` clarifying that sponsorship does not guarantee inclusion, ranking, endorsement, or editorial preference. 

### Testing
- Ran `npm run lint` (`tsc --noEmit`) which completed successfully. 
- Ran `npm run build` (`vite build`) which completed successfully and produced a production build. 
- No changes to sorting, filtering, or ranking logic were introduced and non-sponsored entries remain unaffected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0229dadb8c832a9fb83a9094eb5597)