### PR TITLE
Update data.ts: Add AMYboard online

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -11,10 +11,10 @@ export const initialSites: Site[] = [
   },
   {
     id: 'amyboard',
-    name: 'AMYboard Online’,
+    name: 'AMYboard Online',
     url: 'https://www.amyboard.com/editor/',
-    tags: ['hardware', 'config', 'utility', 'firmware', 'webmidi', 'synth'],
-    description: 'The do-it-all complete synth for US$29.90.'
+    tags: ['open-source', 'config', 'utility', 'firmware', 'webmidi', 'synth'],
+    description: 'Online editor for AMYboard open-source synth module.',
   },
   {
     id: 'synth-explorer',

--- a/src/data.ts
+++ b/src/data.ts
@@ -12,7 +12,7 @@ export const initialSites: Site[] = [
   {
     id: 'amyboard',
     name: 'AMYboard Online’,
-    url: 'https://www.amyboard.com/',
+    url: 'https://www.amyboard.com/editor/',
     tags: ['hardware', 'config', 'utility', 'firmware', 'webmidi', 'synth'],
     description: 'The do-it-all complete synth for US$29.90.'
   },

--- a/src/data.ts
+++ b/src/data.ts
@@ -10,6 +10,13 @@ export const initialSites: Site[] = [
       'Control the performance of musical scores with the help of a gamepad',
   },
   {
+    id: 'amyboard',
+    name: 'AMYboard Online’,
+    url: 'https://www.amyboard.com/',
+    tags: ['hardware', 'config', 'utility', 'firmware', 'webmidi', 'synth'],
+    description: 'The do-it-all complete synth for US$29.90.'
+  },
+  {
     id: 'synth-explorer',
     name: 'Synth Explorer',
     url: 'https://synth-explorer.com',


### PR DESCRIPTION
This is a new hardware synth / module / devboard that uses webmidi to update firmware, configure the device and load patches onto synthesizers and drum machines that are loaded on  the hardware. From their site (I am just a user, not affiliated):

A full-featured, ready-to-play synthesizer module with lush 80s polyphonic synthesizer emulation. Load shared patches and presets and tweak your synth online.

https://www.amyboard.com/