### PR TITLE
Add ROWBOT to directory

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -245,6 +245,14 @@ export const initialSites: Site[] = [
       since: '2026-05-11',
     },
   },
+  {
+    id: 'rowbot',
+    name: 'ROWBOT',
+    url: 'https://playrowbot.com',
+    tags: ['tracker', 'sequencer', 'synth', 'webaudio', 'midi', 'chiptune'],
+    description:
+      'A browser-based music tracker with synthesized instruments — a whole song fits in a shareable link. Supports MIDI in for note entry and MIDI out for sequencing external hardware and software.',
+  },
 ];
 
 export const allTags = Array.from(


### PR DESCRIPTION
## Summary

Adds [ROWBOT](https://playrowbot.com) to the directory — a browser-based music tracker with synthesized instruments (PULSE, FM, WAVE, RAMEN, and SAMPLE engines), where an entire song compresses to a shareable URL. It supports WebMIDI in both directions:

- **MIDI IN** — a connected keyboard types notes directly into the tracker grid, honoring key/scale snapping and step advance.
- **MIDI OUT** — the tracker sequences external hardware or software, mapping tracker channels to MIDI channels with VOL as velocity.

## Entry

- id: `rowbot`
- name: `ROWBOT`
- url: `https://playrowbot.com`
- tags: `tracker`, `sequencer`, `synth`, `webaudio`, `midi`, `chiptune`

Ran `npm run format:data` (via `npx prettier@3 --write --single-quote src/data.ts`) — file was already correctly formatted, no changes needed beyond the new entry.